### PR TITLE
feat: open a single markdown file directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ notes-app/
 | `Cmd+P` | Quick Open |
 | `Cmd+Shift+E` | Export PDF |
 | `Cmd+Shift+L` | Toggle outline |
-| `Cmd+Shift+O` | Open folder |
+| `Cmd+O` | Open Markdown File |
 
 ## License
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -493,7 +493,7 @@ ipcMain.handle('notes:getAll', async () => {
     if (!currentNotesDir) return [];
     await ensureNotesDir();
     const files = await fs.readdir(currentNotesDir);
-    const mdFiles = files.filter((file) => file.endsWith('.md'));
+    const mdFiles = files.filter((file) => file.match(/\.(md|markdown)$/i));
 
     const notes = await Promise.all(
       mdFiles.map(async (filename) => {
@@ -501,7 +501,7 @@ ipcMain.handle('notes:getAll', async () => {
         const stat = await fs.stat(filepath);
         const content = await fs.readFile(filepath, 'utf-8');
         return {
-          id: filename.replace(/\.md$/i, ''),
+          id: filename.replace(/\.(md|markdown)$/i, ""),
           filename,
           filepath,
           content,
@@ -809,6 +809,41 @@ ipcMain.handle('notes:exportImage', async (_event, data) => {
   }
 });
 
+ipcMain.handle('notes:openFile', async () => {
+  try {
+    const result = await dialog.showOpenDialog({
+      title: 'Open Markdown File',
+      properties: ['openFile'],
+      filters: [{ name: 'Markdown', extensions: ['md', 'markdown'] }],
+    });
+
+    if (result.canceled || result.filePaths.length === 0) {
+      return { success: false, canceled: true };
+    }
+
+    const filePath = result.filePaths[0];
+    const stat = await fs.stat(filePath);
+    const content = await fs.readFile(filePath, 'utf-8');
+
+    currentNotesDir = path.dirname(filePath);
+
+    return {
+      success: true,
+      directory: currentNotesDir,
+      note: {
+        id: path.basename(filePath).replace(/\.(md|markdown)$/i, ""),
+        filename: path.basename(filePath),
+        filepath: filePath,
+        content,
+        modifiedAt: stat.mtime.toISOString(),
+        createdAt: stat.birthtime.toISOString(),
+      },
+    };
+  } catch (err) {
+    return { success: false, error: err?.message || String(err) };
+  }
+});
+
 ipcMain.handle('settings:selectDirectory', async () => {
   const result = await dialog.showOpenDialog({
     properties: ['openDirectory', 'createDirectory'],
@@ -879,7 +914,7 @@ function buildApplicationMenu(mainWindow) {
         { label: 'Save', accelerator: 'CmdOrCtrl+S', click: () => send('save-note') },
         { label: 'Save As…', accelerator: 'CmdOrCtrl+Shift+S', click: () => send('save-note-as') },
         { type: 'separator' },
-        { label: 'Open Folder…', accelerator: 'CmdOrCtrl+Shift+O', click: () => send('open-folder') },
+        { label: 'Open Markdown File…', accelerator: 'CmdOrCtrl+O', click: () => send('open-file') },
         { type: 'separator' },
         { label: 'Export PDF…', accelerator: 'CmdOrCtrl+Shift+E', click: () => send('export-pdf') },
         { label: 'Export Image…', click: () => send('export-image') },

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -3,6 +3,7 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electronAPI', {
   setStoragePath: (path) => ipcRenderer.invoke('notes:setStoragePath', path),
   getAllNotes: () => ipcRenderer.invoke('notes:getAll'),
+  openMarkdownFile: () => ipcRenderer.invoke('notes:openFile'),
   saveNote: (data) => ipcRenderer.invoke('notes:save', data),
   saveNoteAs: (data) => ipcRenderer.invoke('notes:saveAs', data),
   deleteNote: (filename) => ipcRenderer.invoke('notes:delete', filename),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -112,7 +112,7 @@ const deriveDocumentTitle = (markdown: string, fallbackTitle?: string, filename?
   const trimmedFallback = fallbackTitle?.trim();
   if (trimmedFallback && trimmedFallback !== 'Untitled') return trimmedFallback;
 
-  const trimmedFilename = filename?.replace(/\.md$/i, '').trim();
+  const trimmedFilename = filename?.replace(/\.(md|markdown)$/i, '').trim();
   if (trimmedFilename) return trimmedFilename;
 
   return 'Untitled';
@@ -138,7 +138,6 @@ function App() {
   const [notes, setNotes] = useState<Note[]>([]);
   const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [isOpeningFolder, setIsOpeningFolder] = useState(false);
   const [recentNoteIds, setRecentNoteIds] = useState<string[]>(() => getSavedRecentNoteIds());
   const [isQuickOpenOpen, setIsQuickOpenOpen] = useState(false);
   const [quickOpenQuery, setQuickOpenQuery] = useState('');
@@ -165,7 +164,7 @@ function App() {
   const makeUniqueFilename = useCallback(
     (title: string, excludeFilename?: string) => {
       const baseFilename = generateFilename(title);
-      const baseName = baseFilename.replace(/\.md$/i, '');
+      const baseName = baseFilename.replace(/\.(md|markdown)$/i, '');
       const excluded = excludeFilename?.toLowerCase();
       const existingFilenames = new Set(
         notes
@@ -188,27 +187,6 @@ function App() {
     [notes]
   );
 
-  const loadNotes = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const rawNotes: RawNote[] = await window.electronAPI.getAllNotes();
-      const parsedNotes: Note[] = rawNotes.map((note) => {
-        const parsed = parseNote(note.content, note.filename);
-        return {
-          ...note,
-          ...parsed,
-          modifiedAt: new Date(note.modifiedAt),
-          createdAt: new Date(note.createdAt),
-        };
-      });
-      setNotes(parsedNotes);
-    } catch (err) {
-      console.error('Failed to load documents:', err);
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
   useEffect(() => {
     if (notes.length === 0) {
       setSelectedNoteId(null);
@@ -230,11 +208,10 @@ function App() {
   }, []);
 
   useEffect(() => {
-    if (isOpeningFolder) return;
     if (selectedNoteId) return;
     if (draftNote) return;
     setDraftNote(createDraftNote());
-  }, [draftNote, isOpeningFolder, selectedNoteId]);
+  }, [draftNote, selectedNoteId]);
 
   useEffect(() => {
     if (!selectedNoteId) return;
@@ -321,7 +298,7 @@ function App() {
           : undefined;
         const parsed = parseNote(fileContent, saveAsResult.filename);
         const savedNote: Note = {
-          id: saveAsResult.filename.replace(/\.md$/i, ''),
+          id: saveAsResult.filename.replace(/\.(md|markdown)$/i, ''),
           filename: saveAsResult.filename,
           filepath: saveAsResult.filepath,
           content: fileContent,
@@ -354,7 +331,7 @@ function App() {
       const previousFilename = noteData.filename?.trim();
       const forcedFilename = noteData.forceFilename?.trim();
       const filename = forcedFilename || previousFilename || generateFilename(noteData.title);
-      const noteId = (filename || '').replace(/\.md$/i, '');
+      const noteId = (filename || '').replace(/\.(md|markdown)$/i, '');
       const existingNote = notesRef.current.find((note) => note.id === noteData.id || note.filename === previousFilename);
       const fileContent = generateNoteContent(noteData.content);
 
@@ -496,8 +473,8 @@ function App() {
       const renderedHtml = exportHtmlGetterRef.current?.() || '';
       const html = renderedHtml || await markdownToExportHtml(markdown);
       const suggestedBaseName = current.filename
-        ? current.filename.replace(/\.md$/i, '')
-        : generateFilename(documentTitle).replace(/\.md$/i, '');
+        ? current.filename.replace(/\.(md|markdown)$/i, '')
+        : generateFilename(documentTitle).replace(/\.(md|markdown)$/i, '');
 
       const result = await window.electronAPI.exportNotePdf({
         title: documentTitle,
@@ -534,8 +511,8 @@ function App() {
       const renderedHtml = exportHtmlGetterRef.current?.() || '';
       const html = renderedHtml || await markdownToExportHtml(markdown);
       const suggestedBaseName = current.filename
-        ? current.filename.replace(/\.md$/i, '')
-        : generateFilename(documentTitle).replace(/\.md$/i, '');
+        ? current.filename.replace(/\.(md|markdown)$/i, '')
+        : generateFilename(documentTitle).replace(/\.(md|markdown)$/i, '');
 
       const result = await window.electronAPI.exportNoteImage({
         title: documentTitle,
@@ -558,24 +535,33 @@ function App() {
     }
   }, []);
 
-  const handleOpenFolder = useCallback(async () => {
-    const selectedPath = await window.electronAPI.selectDirectory();
-    if (!selectedPath) return;
+  const handleOpenMarkdownFile = useCallback(async () => {
+    const result = await window.electronAPI.openMarkdownFile?.();
+    if (!result || result.canceled) return;
 
-    const result = await window.electronAPI.setStoragePath(selectedPath);
-    if (!result.success) return;
-
-    const nextPath = result.path || selectedPath;
-    activeDirectoryRef.current = nextPath;
-    setIsOpeningFolder(true);
-    setSelectedNoteId(null);
-    setDraftNote(null);
-    try {
-      await loadNotes();
-    } finally {
-      setIsOpeningFolder(false);
+    if (!result.success || !result.note) {
+      console.error('Failed to open markdown file:', result.error);
+      return;
     }
-  }, [loadNotes]);
+
+    const nextRawNote = result.note;
+    const parsed = parseNote(nextRawNote.content, nextRawNote.filename);
+    const openedNote: Note = {
+      ...nextRawNote,
+      ...parsed,
+      modifiedAt: new Date(nextRawNote.modifiedAt),
+      createdAt: new Date(nextRawNote.createdAt),
+    };
+
+    if (result.directory) {
+      activeDirectoryRef.current = result.directory;
+    }
+
+    setDraftNote(null);
+    setNotes([openedNote]);
+    setSelectedNoteId(openedNote.id);
+    setIsQuickOpenOpen(false);
+  }, []);
 
   useEffect(() => {
     const unsubscribe = window.electronAPI.onMenuAction((action) => {
@@ -595,8 +581,8 @@ function App() {
         case 'export-image':
           void exportCurrentDocumentAsImage();
           break;
-        case 'open-folder':
-          void handleOpenFolder();
+        case 'open-file':
+          void handleOpenMarkdownFile();
           break;
         case 'toggle-outline':
           setOutlineToggleKey((prev) => prev + 1);
@@ -607,7 +593,7 @@ function App() {
     });
 
     return unsubscribe;
-  }, [exportCurrentDocument, exportCurrentDocumentAsImage, handleCreateNote, handleOpenFolder, saveCurrentDocument, saveCurrentDocumentAs]);
+  }, [exportCurrentDocument, exportCurrentDocumentAsImage, handleCreateNote, handleOpenMarkdownFile, saveCurrentDocument, saveCurrentDocumentAs]);
 
   const recentNotes = useMemo(
     () =>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,6 +21,14 @@ export interface RawNote {
   createdAt: string;
 }
 
+export interface OpenMarkdownFileResult {
+  success: boolean;
+  canceled?: boolean;
+  note?: RawNote;
+  directory?: string;
+  error?: string;
+}
+
 export interface ExportPdfOptions {
   pageSize: 'A4' | 'Letter';
   orientation: 'portrait' | 'landscape';
@@ -116,6 +124,7 @@ export interface SettingsMenuItem {
 export interface ElectronAPI {
   setStoragePath: (path: string) => Promise<{ success: boolean; path?: string; error?: string }>;
   getAllNotes: () => Promise<RawNote[]>;
+  openMarkdownFile?: () => Promise<OpenMarkdownFileResult>;
   saveNote: (data: { filename: string; content: string; preserveModifiedAt?: boolean }) => Promise<{ success: boolean; error?: string }>;
   saveNoteAs?: (data: { suggestedFilename: string; content: string }) => Promise<{ success: boolean; canceled?: boolean; filepath?: string; filename?: string; directory?: string; error?: string }>;
   deleteNote: (filename: string) => Promise<{ success: boolean; error?: string }>;


### PR DESCRIPTION
## Summary

Add a direct `Open Markdown File…` flow so the editor can open one specific `.md` or `.markdown` file without entering a folder-browsing mode.

## What changed

- add `notes:openFile` IPC to open a single markdown file from the system file picker
- expose `openMarkdownFile()` in the preload bridge and renderer types
- replace the File menu item with `Open Markdown File…` on `Cmd+O`
- load the selected markdown file directly into the editor instead of loading a whole directory
- normalize `.md` and `.markdown` handling across open, save, and export naming paths
- update README shortcut docs

## Validation

- `node -c electron/main.cjs`
- TypeScript syntax check for `src/App.tsx` via `typescript.transpileModule`

## Notes

This PR is stacked on top of #3 and should be reviewed against `codex/fix-editor-first-flow`.