### PR TITLE
feat: 无标题时隐藏 Outline，并统一其样式与正文一致

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -648,6 +648,7 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  font-family: var(--editor-prose-font);
   border: 1px solid var(--editor-outline-border, rgba(120, 102, 76, 0.12));
   border-radius: 18px;
   background: var(--editor-outline-bg, #f0eee6);
@@ -697,6 +698,7 @@
   background: transparent;
   color: var(--editor-outline-text, rgba(67, 73, 79, 0.86));
   text-align: left;
+  font-family: var(--editor-prose-font);
   font-size: 13px;
   line-height: 1.4;
   border-radius: 12px;
@@ -708,15 +710,15 @@
 }
 
 .editor-outline-item:hover {
-  background: var(--editor-outline-active-bg, rgba(255, 255, 255, 0.6));
-  border-color: var(--editor-outline-border, rgba(120, 102, 76, 0.1));
+  background: transparent;
+  border-color: transparent;
   color: var(--editor-outline-active-text, #1f2732);
 }
 
 .editor-outline-item.active {
-  background: var(--editor-outline-active-bg, rgba(255, 252, 247, 0.92));
-  border-color: var(--editor-outline-border, rgba(120, 102, 76, 0.16));
-  color: var(--editor-outline-active-text, #1f2732);
+  background: transparent;
+  border-color: transparent;
+  color: var(--editor-strong-color, rgb(193, 95, 60));
   font-weight: 600;
 }
 

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -269,7 +269,7 @@ function Editor({
       </header>
 
       <div className="editor-content-shell">
-        {isOutlineOpen && (
+        {isOutlineOpen && outlineItems.length > 0 && (
           <div className="editor-outline-floating">
             <div
               className={`editor-outline-dock${isOutlineHovered ? ' expanded' : ''}`}


### PR DESCRIPTION
## 改动内容

针对悬浮 Outline 的可见性与样式优化：

- **无标题时不显示 Outline**：当文档没有任何标题时，整个悬浮 Outline（含右侧 rail）不再出现；只有文档存在标题时才显示。
- **去掉白色高亮**：移除 Outline 列表项 hover / active 状态的白色背景框与边框。
- **加粗色与正文一致**：选中项加粗时使用正文加粗的 `--editor-strong-color`（赤陶橙），不再用黑色。
- **字体与正文一致**：Outline 卡片及标题项改用 `--editor-prose-font`。修复了标题项是 `<button>` 不继承父级字体、导致只有 header 生效的问题。

## 影响范围

仅 `src/components/Editor/Editor.tsx` 与 `src/components/Editor/Editor.css`，纯 UI 行为/样式改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)