### PR TITLE
feat: 编辑器顶部可编辑文件名，并自动跟随标题

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -332,7 +332,10 @@ function App() {
       }
 
       const previousFilename = noteData.filename?.trim();
-      const forcedFilename = noteData.forceFilename?.trim();
+      const forcedBase = noteData.forceFilename?.trim().replace(/\.(md|markdown)$/i, '');
+      // A forced rename is treated as a desired base name: sanitize it and make
+      // it unique so we never clobber another note's file.
+      const forcedFilename = forcedBase ? makeUniqueFilename(forcedBase, previousFilename) : '';
       const filename = forcedFilename || previousFilename || generateFilename(noteData.title);
       const noteId = (filename || '').replace(/\.(md|markdown)$/i, '');
       const existingNote = notesRef.current.find((note) => note.id === noteData.id || note.filename === previousFilename);
@@ -348,7 +351,15 @@ function App() {
         throw new Error(saveResult.error || 'Failed to save document');
       }
 
-      if (previousFilename && forcedFilename && forcedFilename !== previousFilename) {
+      // Remove the old file after a rename, but never when the names differ only
+      // by case: on case-insensitive filesystems that is the same file and the
+      // delete would wipe what we just wrote.
+      if (
+        previousFilename &&
+        forcedFilename &&
+        forcedFilename !== previousFilename &&
+        forcedFilename.toLowerCase() !== previousFilename.toLowerCase()
+      ) {
         const deleteResult = await window.electronAPI.deleteNote(previousFilename);
         if (!deleteResult.success) {
           console.warn('Failed to remove old filename after rename:', deleteResult.error);

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -90,15 +90,52 @@
   left: 50%;
   transform: translateX(-50%);
   max-width: min(58%, 520px);
+  display: flex;
+  justify-content: center;
+}
+
+.editor-title-button,
+.editor-title-input {
+  max-width: 100%;
   font-size: 13px;
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--editor-text-muted);
   text-align: center;
+  font-family: inherit;
+}
+
+.editor-title-button {
+  max-width: 520px;
+  border: none;
+  background: transparent;
+  padding: 2px 8px;
+  border-radius: 7px;
+  cursor: pointer;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  transition: background 0.16s ease, color 0.16s ease;
+}
+
+.editor-title-button:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--editor-text-muted) 12%, transparent);
+  color: var(--editor-text);
+}
+
+.editor-title-button:disabled {
+  cursor: default;
+}
+
+.editor-title-input {
+  width: min(60vw, 520px);
+  border: none;
+  border-radius: 7px;
+  padding: 2px 8px;
+  background: color-mix(in srgb, var(--editor-text-muted) 10%, transparent);
+  outline: none;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--editor-accent) 40%, transparent);
 }
 
 .editor-word-count {

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -1,7 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import MarkdownLiveEditor from './MarkdownLiveEditor';
 import type { EditorNote, SaveNoteData } from '../../types';
+import { generateFilename, getFirstHeading } from '../../utils/noteUtils';
 import './Editor.css';
+
+const filenameBase = (filename?: string): string =>
+  (filename || '').replace(/\.(md|markdown)$/i, '');
+
+const headingSlugBase = (heading: string): string =>
+  generateFilename(heading).replace(/\.(md|markdown)$/i, '');
 
 interface EditorProps {
   note: EditorNote | null;
@@ -40,6 +47,8 @@ function Editor({
   const [activeOutlineItemId, setActiveOutlineItemId] = useState<string | null>(null);
   const [isOutlineHovered, setIsOutlineHovered] = useState(false);
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [nameDraft, setNameDraft] = useState('');
 
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const outlineHoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -49,6 +58,11 @@ function Editor({
   const draftContentRef = useRef('');
   const documentTitleRef = useRef('');
   const onSaveRef = useRef(onSave);
+  const nameInputRef = useRef<HTMLInputElement>(null);
+  // Whether the filename should keep tracking the first heading. Locked once
+  // the user renames the file by hand; re-inferred whenever a note loads.
+  const nameFollowsHeadingRef = useRef(true);
+  const lastSyncedHeadingRef = useRef('');
 
   useEffect(() => {
     onSaveRef.current = onSave;
@@ -113,10 +127,27 @@ function Editor({
     async (noteSnapshot: EditorNote | null | undefined, interactive = false) => {
       if (!noteSnapshot) return;
       clearPendingSave();
+
+      // While the filename still follows the heading, rename the file to match
+      // the first heading whenever it changes. Skipped for drafts (no file yet)
+      // and when the heading is empty (don't rename to "Untitled").
+      let forceFilename: string | undefined;
+      const heading = getFirstHeading(draftContentRef.current);
+      if (
+        nameFollowsHeadingRef.current &&
+        noteSnapshot.filename &&
+        heading &&
+        heading !== lastSyncedHeadingRef.current &&
+        headingSlugBase(heading) !== filenameBase(noteSnapshot.filename)
+      ) {
+        forceFilename = heading;
+      }
+
       await onSaveRef.current({
         id: noteSnapshot.id,
         filename: noteSnapshot.filename,
         filepath: noteSnapshot.filepath,
+        forceFilename,
         title: documentTitleRef.current,
         content: draftContentRef.current,
         tags: [],
@@ -124,6 +155,8 @@ function Editor({
         interactive,
         isDraft: noteSnapshot.isDraft,
       });
+
+      if (heading) lastSyncedHeadingRef.current = heading;
     },
     [clearPendingSave]
   );
@@ -132,6 +165,16 @@ function Editor({
     const activeNote = note;
     setContent(activeNote?.content || '');
     skipNextAutoSaveRef.current = true;
+    setIsEditingName(false);
+
+    // Re-infer whether the filename is still tracking the heading. A draft (no
+    // file yet) always follows; a saved file follows only when its name still
+    // matches the slug of its current first heading.
+    const heading = getFirstHeading(activeNote?.content || '');
+    lastSyncedHeadingRef.current = heading;
+    nameFollowsHeadingRef.current = !activeNote?.filename
+      ? true
+      : Boolean(heading) && headingSlugBase(heading) === filenameBase(activeNote.filename);
 
     return () => {
       clearPendingSave();
@@ -190,6 +233,59 @@ function Editor({
   const handleActiveOutlineItemChange = useCallback((itemId: string | null) => {
     setActiveOutlineItemId((prev) => (prev === itemId ? prev : itemId));
   }, []);
+
+  // The filename shown in the header rail. Saved notes show the real filename;
+  // an unsaved draft previews the name it will take (heading slug or Untitled).
+  const headingName = useMemo(() => getFirstHeading(content), [content]);
+  const displayName = note?.filename
+    ? filenameBase(note.filename)
+    : headingName || 'Untitled';
+  const canRename = Boolean(note?.filename);
+
+  // A stable key for the underlying document so that renaming the file (which
+  // changes note.id) does not remount the editor and lose the caret.
+  const documentKey = useMemo(() => {
+    if (!note) return '';
+    const created = note.createdAt instanceof Date ? note.createdAt.getTime() : NaN;
+    return Number.isNaN(created) ? note.id : `doc-${created}`;
+  }, [note?.id, note?.createdAt]);
+
+  const startNameEdit = useCallback(() => {
+    if (!note?.filename) return;
+    setNameDraft(filenameBase(note.filename));
+    setIsEditingName(true);
+  }, [note?.filename]);
+
+  const commitNameEdit = useCallback(() => {
+    setIsEditingName(false);
+    const activeNote = note;
+    if (!activeNote?.filename) return;
+    const value = nameDraft.trim();
+    if (!value || value === filenameBase(activeNote.filename)) return;
+
+    clearPendingSave();
+    nameFollowsHeadingRef.current = false;
+    void onSaveRef.current({
+      id: activeNote.id,
+      filename: activeNote.filename,
+      filepath: activeNote.filepath,
+      forceFilename: value,
+      title: value,
+      content: draftContentRef.current,
+      tags: [],
+      date: activeNote.date,
+      interactive: false,
+      isDraft: activeNote.isDraft,
+    });
+  }, [clearPendingSave, nameDraft, note]);
+
+  useEffect(() => {
+    if (!isEditingName) return;
+    const input = nameInputRef.current;
+    if (!input) return;
+    input.focus();
+    input.select();
+  }, [isEditingName]);
 
   useEffect(() => {
     return () => {
@@ -261,7 +357,39 @@ function Editor({
       <header className="editor-header editor-header-minimal">
         <div className="editor-header-side editor-header-left" aria-hidden="true" />
 
-        <div className="editor-title-rail">{documentTitle}</div>
+        <div className="editor-title-rail">
+          {isEditingName ? (
+            <input
+              ref={nameInputRef}
+              type="text"
+              className="editor-title-input"
+              value={nameDraft}
+              onChange={(e) => setNameDraft(e.target.value)}
+              onBlur={commitNameEdit}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  commitNameEdit();
+                } else if (e.key === 'Escape') {
+                  e.preventDefault();
+                  setIsEditingName(false);
+                }
+              }}
+              spellCheck={false}
+              aria-label="File name"
+            />
+          ) : (
+            <button
+              type="button"
+              className="editor-title-button"
+              onClick={startNameEdit}
+              disabled={!canRename}
+              title={canRename ? 'Click to rename file' : undefined}
+            >
+              {displayName}
+            </button>
+          )}
+        </div>
 
         <div className="editor-header-side editor-header-right">
           <span className="editor-word-count">{wordCountLabel}</span>
@@ -331,7 +459,7 @@ function Editor({
                 onActiveOutlineItemChange={handleActiveOutlineItemChange}
                 onRegisterOutlineNavigator={handleRegisterOutlineNavigator}
                 onRegisterExportHtmlGetter={onRegisterExportHtmlGetter}
-                documentKey={note.id}
+                documentKey={documentKey}
               />
             </div>
           </div>

--- a/src/utils/noteUtils.ts
+++ b/src/utils/noteUtils.ts
@@ -39,6 +39,16 @@ export function generateNoteContent(body: string): string {
   return normalizeSavedMarkdown(body);
 }
 
+// Returns the text of the first Markdown heading (any level), or '' when none.
+export function getFirstHeading(markdown: string): string {
+  const lines = String(markdown || '').split('\n');
+  for (const line of lines) {
+    const match = line.match(/^\s{0,3}#{1,6}\s+(.*\S)\s*$/);
+    if (match) return match[1].trim();
+  }
+  return '';
+}
+
 export function generateFilename(title: string): string {
   const fallbackTitle = 'Untitled Note';
   const trimmed = title.trim();


### PR DESCRIPTION
## 改动内容

把编辑器顶部居中的标题区从「只读的文档标题」改造成「真正的文件名」，可点击重命名，并在未手动改名前自动跟随文章第一个标题。

### 交互
- **已保存笔记**：显示真实文件名（去 `.md`），点击 → 输入框 → `Enter`/失焦提交重命名，`Esc` 取消。
- **草稿（未保存）**：只读显示标题派生名或 `Untitled`，落盘后才可改名（避免对磁盘上尚不存在的文件做删改）。

### 自动跟随 / 锁定
- 未手动改名时，文件名跟随第一个标题；标题变化触发自动重命名。
- 手动改名即锁定，之后改标题不再自动重命名。
- 跟随/锁定状态在**加载时按「文件名是否等于标题 slug」重新推断**，无需写入元数据即可跨重启保持。
- 删除标题（无标题）时不会把文件改成 `Untitled`。

### 稳定性与安全
- 编辑器 `documentKey` 改用 `createdAt` 派生：自动重命名会改变 `note.id`，旧逻辑会**重建编辑器、丢失光标**，现已避免。
- `forceFilename` 重命名路径**清洗 + 去重**（`makeUniqueFilename`），绝不覆盖其它笔记文件。
- 删除旧文件加**大小写不敏感守卫**，避免 macOS 上仅改大小写时误删数据。
- 新增 `getFirstHeading()` 工具函数。

## 测试
- 本地 `npm run typecheck` 与 `npm run lint` 均通过。
- 建议手动验证：新建打标题保存、改标题触发自动重命名、点击手动改名锁定、重启后状态恢复、重命名时光标保持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)