### PR TITLE
feat(note-list): show file name as the card title

### DIFF
--- a/macos/Notely/Notely.xcodeproj/project.pbxproj
+++ b/macos/Notely/Notely.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		96BEB26FE3BE3C1BAB4F8F71 /* NotelyApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F92311962A01A52B450F566 /* NotelyApp.swift */; };
 		97B9840F54C3F8B26A63CC08 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A5693582B5792899EADACC22 /* Assets.xcassets */; };
 		A11EC83643B6760EF2A5FEC0 /* NoteCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AB666D4EA829964BC9AEDD /* NoteCardView.swift */; };
+		7A1B2C3D4E5F60718293A4E6 /* NoteCardSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1B2C3D4E5F60718293A4E5 /* NoteCardSummary.swift */; };
 		B3F55969806245A31F0F94E7 /* WysiwygTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95F04AAD312B1139EC7FA8DC /* WysiwygTextView.swift */; };
 		B6E59F1EB3D9260C1375C59C /* NoteModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 051335655F5AEF97F593867C /* NoteModel.swift */; };
 		BDA671EA0B3446241CA15312 /* FileNoteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9390B0509CE4E1E21BA020B4 /* FileNoteStore.swift */; };
@@ -43,6 +44,7 @@
 		41504AFB5496F8D42652D3DE /* Notely.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Notely.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		42B5746C3AF4A0D882715D97 /* EditorContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorContainerView.swift; sourceTree = "<group>"; };
 		47AB666D4EA829964BC9AEDD /* NoteCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteCardView.swift; sourceTree = "<group>"; };
+		7A1B2C3D4E5F60718293A4E5 /* NoteCardSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteCardSummary.swift; sourceTree = "<group>"; };
 		4A7B5B3D54248B16FAE60081 /* TitleExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleExtractor.swift; sourceTree = "<group>"; };
 		62A4085CE734D06BACDB912F /* ColorTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorTokens.swift; sourceTree = "<group>"; };
 		65A3B1ABF107ECCBBF6D9172 /* ImageAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachment.swift; sourceTree = "<group>"; };
@@ -192,6 +194,7 @@
 			children = (
 				C7A27F620B88621EE564C564 /* EmptyStateView.swift */,
 				47AB666D4EA829964BC9AEDD /* NoteCardView.swift */,
+				7A1B2C3D4E5F60718293A4E5 /* NoteCardSummary.swift */,
 				0D1067E68B0012FB420F1D40 /* NoteListView.swift */,
 			);
 			path = NoteList;
@@ -278,6 +281,7 @@
 				7A1B2C3D4E5F60718293A4B6 /* MarkdownTable.swift in Sources */,
 				7A1B2C3D4E5F60718293A4C6 /* LatexMath.swift in Sources */,
 				A11EC83643B6760EF2A5FEC0 /* NoteCardView.swift in Sources */,
+				7A1B2C3D4E5F60718293A4E6 /* NoteCardSummary.swift in Sources */,
 				87E6A02F8DD5E62C1A119B90 /* NoteListView.swift in Sources */,
 				B6E59F1EB3D9260C1375C59C /* NoteModel.swift in Sources */,
 				96BEB26FE3BE3C1BAB4F8F71 /* NotelyApp.swift in Sources */,

--- a/macos/Notely/Notely/Views/NoteList/NoteCardSummary.swift
+++ b/macos/Notely/Notely/Views/NoteList/NoteCardSummary.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Computes the one-line preview shown under a note's title in the list.
+///
+/// The title now shows the file name, so the preview must show the note's first
+/// line of *content* — but a note commonly opens with a YAML frontmatter block
+/// (`--- … ---`), whose delimiter is not content. This skips a leading
+/// frontmatter block and returns the first non-empty line after it.
+///
+/// Extracted from `NoteCardView` as a pure function so it can be unit tested
+/// without SwiftUI. Returns `nil` when there is no displayable content.
+enum NoteCardSummary {
+    static func firstContentLine(of content: String) -> String? {
+        let lines = content.components(separatedBy: "\n")
+        var index = firstNonBlank(in: lines, from: 0)
+
+        // Skip a leading YAML frontmatter block, but only when it is actually
+        // closed by a second `---`. An unterminated leading `---` is treated as
+        // ordinary content (e.g. a stray horizontal rule).
+        if index < lines.count, isDelimiter(lines[index]) {
+            var j = index + 1
+            while j < lines.count {
+                if isDelimiter(lines[j]) {
+                    index = firstNonBlank(in: lines, from: j + 1)
+                    break
+                }
+                j += 1
+            }
+        }
+
+        guard index < lines.count else { return nil }
+        return lines[index].trimmingCharacters(in: .whitespaces)
+    }
+
+    private static func isDelimiter(_ line: String) -> Bool {
+        line.trimmingCharacters(in: .whitespaces) == "---"
+    }
+
+    /// Index of the first line that is not blank, starting at `start`; returns
+    /// `lines.count` when every line from `start` on is blank.
+    private static func firstNonBlank(in lines: [String], from start: Int) -> Int {
+        var i = start
+        while i < lines.count, lines[i].trimmingCharacters(in: .whitespaces).isEmpty {
+            i += 1
+        }
+        return i
+    }
+}

--- a/macos/Notely/Notely/Views/NoteList/NoteCardView.swift
+++ b/macos/Notely/Notely/Views/NoteList/NoteCardView.swift
@@ -9,18 +9,7 @@ struct NoteCardView: View {
     @State private var isHovered = false
 
     private var summary: String {
-        let lines = note.content.components(separatedBy: "\n")
-        var foundTitle = false
-        for line in lines {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if trimmed.isEmpty { continue }
-            if !foundTitle {
-                foundTitle = true
-                continue
-            }
-            return trimmed
-        }
-        return "No additional text"
+        NoteCardSummary.firstContentLine(of: note.content) ?? "No additional text"
     }
 
     var body: some View {
@@ -31,7 +20,7 @@ struct NoteCardView: View {
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 5) {
-                    Text(highlighted(note.title.isEmpty ? note.filename : note.title))
+                    Text(highlighted(note.filename))
                         .font(.system(size: 14, weight: isSelected ? .semibold : .medium))
                         .foregroundColor(.primaryText)
                         .lineLimit(1)

--- a/macos/Notely/Tests/NoteCardSummaryTests.swift
+++ b/macos/Notely/Tests/NoteCardSummaryTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+// Standalone test runner for NoteCardSummary. No Xcode test target exists, and
+// NoteCardSummary has no SwiftUI dependency, so this compiles directly with the
+// source file:
+//
+//     swiftc Notely/Views/NoteList/NoteCardSummary.swift Tests/NoteCardSummaryTests.swift -o /tmp/summary-tests
+//     /tmp/summary-tests
+//
+// Exits non-zero if any assertion fails.
+
+@main
+enum NoteCardSummaryTests {
+    static var failures = 0
+    static var checks = 0
+
+    static func expect(_ actual: String?, _ expected: String?, _ message: String) {
+        checks += 1
+        if actual != expected {
+            failures += 1
+            let a = actual.map { "\"\($0)\"" } ?? "nil"
+            let e = expected.map { "\"\($0)\"" } ?? "nil"
+            FileHandle.standardError.write("FAIL: \(message) — expected \(e), got \(a)\n".data(using: .utf8)!)
+        }
+    }
+
+    static func main() {
+        // Plain content: first non-empty line.
+        expect(NoteCardSummary.firstContentLine(of: "Hello\nWorld"), "Hello",
+               "plain content returns first line")
+
+        // The first line is no longer skipped (the title moved to the file name).
+        expect(NoteCardSummary.firstContentLine(of: "First line\nSecond line"), "First line",
+               "does not skip the first content line")
+
+        // Leading blank lines are skipped.
+        expect(NoteCardSummary.firstContentLine(of: "\n\n  \nReal start"), "Real start",
+               "leading blank lines skipped")
+
+        // YAML frontmatter block is skipped; preview shows real content.
+        let fm = "---\ntitle: \"2026-03-08\"\ntags: [ai]\n---\n今天是 2026 年 3 月 8 日"
+        expect(NoteCardSummary.firstContentLine(of: fm), "今天是 2026 年 3 月 8 日",
+               "leading frontmatter block is skipped")
+
+        // Frontmatter followed by blank lines before content.
+        let fmBlank = "---\ntitle: x\n---\n\n\nBody after blanks"
+        expect(NoteCardSummary.firstContentLine(of: fmBlank), "Body after blanks",
+               "blank lines after frontmatter are skipped too")
+
+        // A note that is ONLY frontmatter has no displayable content.
+        expect(NoteCardSummary.firstContentLine(of: "---\ntitle: x\ntags: [a]\n---\n"), nil,
+               "frontmatter-only note has no content line")
+
+        // An unterminated leading `---` is treated as ordinary content, not
+        // frontmatter (so we don't swallow the whole note).
+        expect(NoteCardSummary.firstContentLine(of: "---\nstill content"), "---",
+               "unterminated leading --- is treated as content")
+
+        // A Markdown heading is shown as-is (we only changed frontmatter handling).
+        expect(NoteCardSummary.firstContentLine(of: "# Heading\nbody"), "# Heading",
+               "markdown heading shown as first line")
+
+        // Empty / whitespace-only content yields nil.
+        expect(NoteCardSummary.firstContentLine(of: ""), nil, "empty content -> nil")
+        expect(NoteCardSummary.firstContentLine(of: "   \n\n"), nil, "blank-only content -> nil")
+
+        if failures == 0 {
+            print("OK — all \(checks) NoteCardSummary checks passed")
+            exit(0)
+        } else {
+            FileHandle.standardError.write("\(failures)/\(checks) NoteCardSummary checks FAILED\n".data(using: .utf8)!)
+            exit(1)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
The middle-column note cards derived their title from the note's *content* (first line / H1). This switches the title to the **file name** — the note's stable identity — with the existing `lineLimit(1)` + tail truncation ellipsizing long names.

Because the first content line is no longer the title, the preview no longer skips it. To avoid frontmatter-heavy notes showing `---` as their preview, the preview skips a *closed* leading YAML frontmatter block and shows the first real content line. That logic is extracted into the pure `NoteCardSummary` for testability.

## Testing
- New `Tests/NoteCardSummaryTests.swift` — standalone `swiftc` runner (no Xcode test target exists). 10 checks: plain content, no first-line skip, frontmatter skipping, blank lines after frontmatter, frontmatter-only notes, unterminated `---`, markdown headings, empty/blank input. All pass.
- `xcodebuild` of the app target: **BUILD SUCCEEDED**.
- Ran the app against a real vault and screenshot-verified: titles now show file names, and a frontmatter note's preview changed from `---` to its first real content line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)